### PR TITLE
Fix unused imports

### DIFF
--- a/ltv_cac_simulator.py
+++ b/ltv_cac_simulator.py
@@ -1,14 +1,9 @@
 import streamlit as st
 import numpy as np
 import pandas as pd
-import matplotlib.pyplot as plt
-import seaborn as sns
 import plotly.graph_objects as go
-import plotly.express as px
 from plotly.subplots import make_subplots
-from datetime import datetime, timedelta
-import random
-from typing import Dict, List, Tuple, Optional
+from typing import Dict, List
 
 # Конфигурация
 st.set_page_config(


### PR DESCRIPTION
## Summary
- remove unused imports from main module

## Testing
- `python -m py_compile ltv_cac_simulator.py`
- `python ltv_cac_simulator.py`

------
https://chatgpt.com/codex/tasks/task_e_6840142c1bb48327a68b8e981e40bc09